### PR TITLE
Rename package to TZJData

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "TZJFileData"
+name = "TZJData"
 uuid = "dc5dba14-91b3-4cab-a142-028a31da12f7"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
 version = "0.0.1"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TZJFileData
+# TZJData
 
-[![Build Status](https://github.com/JuliaTime/TZJFileData.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaTime/TZJFileData.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Build Status](https://github.com/JuliaTime/TZJData.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaTime/TZJData.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)

--- a/src/TZJData.jl
+++ b/src/TZJData.jl
@@ -1,4 +1,4 @@
-module TZJFileData
+module TZJData
 
 # Write your package code here.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
-using TZJFileData
+using TZJData
 using Test
 
-@testset "TZJFileData.jl" begin
+@testset "TZJData.jl" begin
     # Write your tests here.
 end


### PR DESCRIPTION
Shorter name that more closely aligns with "tzdata". If the tzfile format uses the magic bytes "TZif" to mean "timezone information file" then "TZjf" can mean "timezone julia file". This package's descriptive name is then "timezone julia data".

Also, best to do this before we register this.