### PR TITLE
Create TZJData artifact constants

### DIFF
--- a/src/TZJData.jl
+++ b/src/TZJData.jl
@@ -2,4 +2,13 @@ module TZJData
 
 using Artifacts
 
+const ARTIFACT_DIR = artifact"tzjdata"
+
+const TZDATA_VERSION = let
+    artifact_dict = Artifacts.parse_toml(joinpath(@__DIR__, "..", "Artifacts.toml"))
+    url = first(artifact_dict["tzjdata"]["download"])["url"]
+    m = match(r"tzdata(?<version>\d{2}\d{2}?[a-z])", url)
+    m !== nothing ? m[:version] : error("Unable to determine tzdata version")
+end
+
 end


### PR DESCRIPTION
Adds the `ARTIFACT_DIR` and `TZDATA_VERSION` contants to the TZJData.jl package. Unfortunately, we have a chicken and egg situation: we do not want to create a tag/release without these changes but these changes cause the TZJData package to fail to load without having the tag/release containing the necessary artifacts.

For now, we'll just accept that the tests will fail with this PR and generate the artifacts we need as a follow up to this PR.