### PR TITLE
Add basic tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,12 @@ version = "0.0.1+2023c"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [compat]
+TimeZones = "1"
 julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [targets]
-test = ["Test"]
+test = ["TimeZones", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,40 @@
 using TZJData
+using TimeZones: TZJFile, TimeZone, Class
 using Test
 
+# TODO: Can be removed once this is in an official TimeZones release
+function _reload_cache!(cache::AbstractDict, compiled_dir::AbstractString)
+    empty!(cache)
+    check = Tuple{String,String}[(compiled_dir, "")]
+
+    for (dir, partial) in check
+        for filename in readdir(dir)
+            startswith(filename, ".") && continue
+
+            path = joinpath(dir, filename)
+            name = isempty(partial) ? filename : join([partial, filename], "/")
+
+            if isdir(path)
+                push!(check, (path, name))
+            else
+                cache[name] = open(TZJFile.read, path, "r")(name)
+            end
+        end
+    end
+
+    return cache
+end
+
 @testset "TZJData.jl" begin
-    # Write your tests here.
+    @test isdir(TZJData.ARTIFACT_DIR)
+    @test occursin(r"^\d{4}[a-z]$", TZJData.TZDATA_VERSION)
+
+    @testset "load compiled" begin
+        cache = Dict{String,Tuple{TimeZone,Class}}()
+        _reload_cache!(cache, TZJData.ARTIFACT_DIR)
+        @test !isempty(cache)
+    end
+
+    # TODO: Check for changes to a `TimeZone`'s `Class` as a change from `Class(:STANDARD)`
+    # to `Class(:LEGACY)` can cause end-users code to break.
 end


### PR DESCRIPTION
Adds some basic tests including:

- Validating the parsed `TZDATA_VERSION` is what we expect
- The compiled tzjfile data can be loaded by TimeZones.jl