### PR TITLE
Update compat for SHA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [compat]
 CodecZlib = "0.7"
-SHA = "1.6"
+SHA = "0.7"
 Tar = "1"
 TimeZones = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [compat]
 CodecZlib = "0.7"
-SHA = "0.7"
+SHA = "0.7, 1.6"
 Tar = "1"
 TimeZones = "1"
 julia = "1.6"


### PR DESCRIPTION
Have a compat entry for SHA that works for both Julia 1.6 and 

Julia 1.12.0-DEV.364
```
ERROR: LoadError: Unsatisfiable requirements detected for package SHA [ea8e919c]:
 SHA [ea8e919c] log:
 ├─possible versions are: 0.7.0 or uninstalled (package in sysimage!)
 └─restricted to versions 1.6.0 - 1 by project [bcd2bfb4] — no versions left
   └─project [bcd2bfb4] log:
     ├─possible versions are: 0.0.0 or uninstalled
     └─project [bcd2bfb4] is fixed to version 0.0.0
```

Julia 1.6.7
```
 ERROR: LoadError: Unsatisfiable requirements detected for package SHA [ea8e919c]:
 SHA [ea8e919c] log:
 ├─possible versions are: 1.6.7 or uninstalled
 └─restricted to versions 0.7 by an explicit requirement — no versions left
```