### PR TITLE
Fix CI path ignoring

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,12 @@
+---
 name: CI
 on:
   pull_request:
   push:
     branches:
       - main
-    paths:
-      - "!Artifacts.toml"  # Impending package release. Will trigger via `tags`
+    paths-ignore:
+      - "Artifacts.toml"  # Impending package release. Will trigger via `tags`
     tags: ["*"]
 concurrency:
   # Skip intermediate builds: on all builds except on the "main" branch.


### PR DESCRIPTION
This restriction was causing CI not to run against `main`.

> If you define a path with the `!` character, you must also define at least one path without the `!` character. If you only want to exclude paths, use `paths-ignore` instead.

– https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths