### PR TITLE
Fix `dorny/paths-filter` on push event

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,14 +22,13 @@ jobs:
       tarball_filename: ${{ steps.key.outputs.tarball_filename }}
       content_hash: ${{ steps.key.outputs.content_hash }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             modified_artifacts_toml:
               - Artifacts.toml
-      - uses: actions/checkout@v4
-        if: ${{ steps.filter.outputs.modified_artifacts_toml == 'true' }}
       - name: Check for unpublished artifact
         if: ${{ steps.filter.outputs.modified_artifacts_toml == 'true' }}
         id: key


### PR DESCRIPTION
Fixing this issue that only appeared on `main` after merging #24.
```
  /usr/bin/git branch --show-current
  fatal: not a git repository (or any of the parent directories): .git
Error: The process '/usr/bin/git' failed with exit code 128
```
– https://github.com/JuliaTime/TZJData.jl/actions/runs/8748575504/job/24008836171

Upstream issue: https://github.com/dorny/paths-filter/issues/212