### PR TITLE
Allow access to the artifact path in a relocatable way

### DIFF
--- a/src/TZJData.jl
+++ b/src/TZJData.jl
@@ -4,6 +4,8 @@ using Artifacts
 
 const ARTIFACT_DIR = artifact"tzjdata"
 
+artifact_dir() = artifact"tzjdata"
+
 const TZDATA_VERSION = let
     artifact_dict = Artifacts.parse_toml(joinpath(@__DIR__, "..", "Artifacts.toml"))
     url = first(artifact_dict["tzjdata"]["download"])["url"]


### PR DESCRIPTION
Half of a possible solution to https://github.com/JuliaTime/TimeZones.jl/issues/467. The other half is at (to be added soon).

Allows accessing the correct artifact path even if the depot has been relocated (e.g. when including the package in a system image).

In theory `artifact_dir()` should always be preferred to `ARTIFACT_DIR` for the above reason, so one would ideally remove `ARTIFACT_DIR` all together. That would be a breaking change though.