### PR TITLE
Use `github.token` for dependabot

### DIFF
--- a/.github/workflows/Update.yaml
+++ b/.github/workflows/Update.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Artifacts
     runs-on: ubuntu-latest
     # These permissions are needed to:
-    # - Create PRs: https://github.com/marketplace/actions/create-pull-request#workflow-permissions
+    # - Create PRs with `github.token`: https://github.com/marketplace/actions/create-pull-request#workflow-permissions
     permissions:
       contents: write
       pull-requests: write
@@ -84,7 +84,7 @@ jobs:
             Artifacts.toml
           commit-message: ${{ steps.build.outputs.commit_message }}
           branch: gh/update-tzdata
-          token: ${{ secrets.TZJDATA_UPDATE_TOKEN }}  # TODO: Fine-grained token expires
+          token: ${{ secrets.TZJDATA_UPDATE_TOKEN || github.token }}  # TODO: Fine-grained token expires
 
   # Work around having GitHub suspend the scheduled workflow if there is no commit activity
   # for the past 60 days. As this repo doesn't get much activity beyond artifact updates


### PR DESCRIPTION
As [dependabot isn't allowed to access repository secrets](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) the "update" workflow fails due to us using `secrets.TZJDATA_UPDATE_TOKEN`. The primary motivation behind using a PAT there is to ensure that workflows created by that PR are automatically triggered. In the case of the dependabot workflow we don't really care about that but we do want the step to execute.