### PR TITLE
List repo artifact to assist in debugging failures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,10 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     needs: unpublished
     runs-on: ${{ matrix.os }}
+    # These permissions are needed to:
+    # - List artifacts
+    permissions:
+      actions: read
     continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
@@ -67,6 +71,16 @@ jobs:
         with:
           workflow: Update.yaml
           name: ${{ needs.unpublished.outputs.key }}
+      # Assists in debugging cross workflow artifact issues
+      - name: List distinct artifacts
+        if: ${{ !cancelled() && steps.action-artifact.outcome == 'faliure' }}
+        run: |
+          # Show the earliest entry for each artifact
+          # https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-artifacts-for-a-repository
+          gh api -X GET "/repos/{owner}/{repo}/actions/artifacts" | jq '.artifacts | sort_by(.created_at) | unique_by(.name)'
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
       - name: Clear cached Overrides.toml
         if: ${{ !needs.unpublished.outputs.key }}
         run: rm -f ~/.julia/artifacts/Overrides.toml

--- a/.github/workflows/Update.yaml
+++ b/.github/workflows/Update.yaml
@@ -17,8 +17,10 @@ jobs:
     name: Artifacts
     runs-on: ubuntu-latest
     # These permissions are needed to:
+    # - List artifacts
     # - Create PRs with `github.token`: https://github.com/marketplace/actions/create-pull-request#workflow-permissions
     permissions:
+      actions: read
       contents: write
       pull-requests: write
     env:
@@ -85,6 +87,15 @@ jobs:
           commit-message: ${{ steps.build.outputs.commit_message }}
           branch: gh/update-tzdata
           token: ${{ secrets.TZJDATA_UPDATE_TOKEN || github.token }}  # TODO: Fine-grained token expires
+      # Assists in debugging cross workflow artifact issues
+      - name: List distinct artifacts
+        run: |
+          # Show the earliest entry for each artifact
+          # https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-artifacts-for-a-repository
+          gh api -X GET "/repos/{owner}/{repo}/actions/artifacts" | jq '.artifacts | sort_by(.created_at) | unique_by(.name)'
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
 
   # Work around having GitHub suspend the scheduled workflow if there is no commit activity
   # for the past 60 days. As this repo doesn't get much activity beyond artifact updates


### PR DESCRIPTION
Should help in debugging failures like I saw in https://github.com/JuliaTime/TZJData.jl/pull/33#issuecomment-2649153926. I think in the long term I should probably be downloading artifacts directly from the list of know artifacts from the repository. That should be rather safe here as we use the git-tree-sha as part of the artifact name.