### PR TITLE
Resolve bundled artifacts without a world-age trampoline

### DIFF
--- a/src/TZJData.jl
+++ b/src/TZJData.jl
@@ -3,8 +3,8 @@ module TZJData
 using Artifacts
 
 # Store the relocatable artifact identity rather than the depot-specific path. Resolve
-# that identity against the runtime artifact directories without the world-age trampoline
-# emitted by the `artifact"..."` macro.
+# it at runtime, with artifact overrides, without the world-age trampoline emitted by
+# the `artifact"..."` macro.
 const _ARTIFACT_HASH = let
     artifacts_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
     hash = Artifacts.artifact_hash("tzjdata", artifacts_toml)
@@ -12,13 +12,7 @@ const _ARTIFACT_HASH = let
     hash
 end
 
-function artifact_dir()
-    dirs = Artifacts.artifacts_dirs(bytes2hex(_ARTIFACT_HASH.bytes))
-    for dir in dirs
-        isdir(dir) && return dir
-    end
-    return first(dirs)
-end
+artifact_dir() = Artifacts.artifact_path(_ARTIFACT_HASH)
 
 # Deprecation for TZJData.jl v1
 Base.@deprecate_binding ARTIFACT_DIR artifact_dir() false

--- a/src/TZJData.jl
+++ b/src/TZJData.jl
@@ -2,11 +2,23 @@ module TZJData
 
 using Artifacts
 
-# Avoid using a constant to define the artifact directory as this will hardcode the path
-# to the location used during pre-compilation which can be problematic if the Julia depot
-# relocated afterwards. One scenario where this can occur is when this package is used
-# within a system image.
-artifact_dir() = artifact"tzjdata"
+# Store the relocatable artifact identity rather than the depot-specific path. Resolve
+# that identity against the runtime artifact directories without the world-age trampoline
+# emitted by the `artifact"..."` macro.
+const _ARTIFACT_HASH = let
+    artifacts_toml = joinpath(@__DIR__, "..", "Artifacts.toml")
+    hash = Artifacts.artifact_hash("tzjdata", artifacts_toml)
+    hash === nothing && error("Unable to determine tzjdata artifact hash")
+    hash
+end
+
+function artifact_dir()
+    dirs = Artifacts.artifacts_dirs(bytes2hex(_ARTIFACT_HASH.bytes))
+    for dir in dirs
+        isdir(dir) && return dir
+    end
+    return first(dirs)
+end
 
 # Deprecation for TZJData.jl v1
 Base.@deprecate_binding ARTIFACT_DIR artifact_dir() false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,22 @@ end
     @test isdir(TZJData.artifact_dir())
     @test occursin(r"^\d{4}[a-z]$", TZJData.TZDATA_VERSION)
 
+    @testset "artifact override" begin
+        override_dir = mktempdir()
+        old_overrides = Artifacts.ARTIFACT_OVERRIDES[]
+        try
+            Artifacts.ARTIFACT_OVERRIDES[] = Dict{Symbol,Any}(
+                :UUID => Dict{Base.UUID,Dict{String,Union{String,SHA1}}}(),
+                :hash => Dict{SHA1,Union{String,SHA1}}(
+                    TZJData._ARTIFACT_HASH => override_dir,
+                ),
+            )
+            @test TZJData.artifact_dir() == override_dir
+        finally
+            Artifacts.ARTIFACT_OVERRIDES[] = old_overrides
+        end
+    end
+
     @testset "validate unpublished artifact" begin
         artifact_toml = get(ENV, "TZJDATA_ARTIFACT_TOML", nothing)
         tarball_path = get(ENV, "TZJDATA_TARBALL_PATH", nothing)


### PR DESCRIPTION
## Summary

Resolve the `tzjdata` artifact at runtime without embedding a depot-specific precompile path or relying on the world-age trampoline emitted by the artifact string macro. This keeps artifact lookup relocatable for bundled system images and trim-compiled executables.

## Implementation

- Read and store the artifact hash from `Artifacts.toml` during precompilation.
- Resolve that hash through `Artifacts.artifact_path` when `artifact_dir` is called.
- Preserve runtime `Overrides.toml` mappings.
- Add a regression test for hash-based artifact overrides.

## Validation

- TZJData tests pass on Julia 1.6 and Julia 1.12.
- A strict JuliaC Tempus workload compiles with zero verifier errors.
- The generated Tempus executable runs successfully.
- The current registered TZJData release reproduces the `Core.invokelatest` verifier error.

Co-authored by Codex
